### PR TITLE
serialization: fix potPubkey calculation

### DIFF
--- a/src/serialisation.rs
+++ b/src/serialisation.rs
@@ -165,9 +165,9 @@ impl From<&SRS> for SRSJson {
             num_g2_powers: g2s.len(),
             powers_of_tau: PowerOfTau {
                 g1_powers: SRS::g1s_to_json_array(g1s),
-                g2_powers: SRS::g2s_to_json_array(g2s)
+                g2_powers: SRS::g2s_to_json_array(g2s),
             },
-            pot_pubkey: SRS::g2s_to_json_array(g2s).get(0).unwrap().to_string(),
+            pot_pubkey: SRS::g2s_to_json_array(g2s).get(1).unwrap().to_string(),
         }
     }
 }


### PR DESCRIPTION
This PR fixes the calculation of `potPubkey` which is the signature of the contribution. This was detected by the [test-vector repo](https://github.com/jsign/kzg-ceremony-test-vectors), which in it's first version used this repo implementation (now uses the sequencer one)..

The code originally targeted `[t^0]_2`, which is always `G2` and not dependent on the secret for the sub-ceremony, which isn't correct.

Considering the assumption that this work is done against the spec `initialContribution.json`, where the starting point of `[t^1]_2` is effective `G2` (t=identity), the first contribution first power of tau value in G2 will always be `[x]_2`, which is the correct value (i.e: index 1).

This repo still isn't suitable for a third or more iterations of contributions since `potPubkey` can't exploit current G2 POT calculations, since they have already baked existing secrets from previous contributions. The correct calculated value should be `[x]_2`.

As a note for other potential readers, you might be interested in looking at the [sequencer repo for a reference implementation](https://github.com/ethereum/kzg-ceremony-sequencer/tree/master/crypto).